### PR TITLE
Update package.json and pnpm-lock.yaml to upgrade turbo to version 2.…

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,26 +1,26 @@
 {
-	"name": "tau",
-	"private": true,
-	"type": "module",
-	"scripts": {
-		"lint": "biome check . --write",
-		"format": "biome format . --write",
-		"typecheck": "tsc",
-		"turbo": "turbo",
-		"test": "turbo run test --concurrency=1",
-		"local": "pnpm --dir=tools/local local",
-		"migrate:prod": "pnpm --dir=packages/db drizzle:prod migrate",
-		"db": "pnpm --dir=packages/db drizzle",
-		"gen:package": "turbo gen workspace --copy @tau/template --type package"
-	},
-	"devDependencies": {
-		"@biomejs/biome": "^1.9.4",
-		"@tau/tsconfig": "workspace:*",
-		"@types/node": "^20.11.17",
-		"@vitest/ui": "^3.0.8",
-		"turbo": "^2.4.4",
-		"typescript": "^5.7.3",
-		"vitest": "^3.0.8"
-	},
-	"packageManager": "pnpm@10.9.0"
+  "name": "tau",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "lint": "biome check . --write",
+    "format": "biome format . --write",
+    "typecheck": "tsc",
+    "turbo": "turbo",
+    "test": "turbo run test --concurrency=1",
+    "local": "pnpm --dir=tools/local local",
+    "migrate:prod": "pnpm --dir=packages/db drizzle:prod migrate",
+    "db": "pnpm --dir=packages/db drizzle",
+    "gen:package": "turbo gen workspace --copy @tau/template --type package"
+  },
+  "devDependencies": {
+    "@biomejs/biome": "^1.9.4",
+    "@tau/tsconfig": "workspace:*",
+    "@types/node": "^20.11.17",
+    "@vitest/ui": "^3.0.8",
+    "turbo": "^2.5.2",
+    "typescript": "^5.7.3",
+    "vitest": "^3.0.8"
+  },
+  "packageManager": "pnpm@10.9.0"
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -49,8 +49,8 @@ importers:
         specifier: ^3.0.8
         version: 3.0.8(vitest@3.0.8)
       turbo:
-        specifier: ^2.4.4
-        version: 2.4.4
+        specifier: ^2.5.2
+        version: 2.5.2
       typescript:
         specifier: ^5.7.3
         version: 5.8.2
@@ -6261,7 +6261,6 @@ packages:
 
   libsql@0.5.7:
     resolution: {integrity: sha512-YbWW3YsGZl6PrBRNAtUVuMLqKRqYcYPa/QqhQCuR67SlcOHIhJ11ksTLAHxXkDRJs6kSrzr9JgGJGJQ91e1Bww==}
-    cpu: [x64, arm64, wasm32]
     os: [darwin, linux, win32]
 
   lightningcss-darwin-arm64@1.29.2:
@@ -8073,38 +8072,38 @@ packages:
   tunnel-agent@0.6.0:
     resolution: {integrity: sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w==}
 
-  turbo-darwin-64@2.4.4:
-    resolution: {integrity: sha512-5kPvRkLAfmWI0MH96D+/THnDMGXlFNmjeqNRj5grLKiry+M9pKj3pRuScddAXPdlxjO5Ptz06UNaOQrrYGTx1g==}
+  turbo-darwin-64@2.5.2:
+    resolution: {integrity: sha512-2aIl0Sx230nLk+Cg2qSVxvPOBWCZpwKNuAMKoROTvWKif6VMpkWWiR9XEPoz7sHeLmCOed4GYGMjL1bqAiIS/g==}
     cpu: [x64]
     os: [darwin]
 
-  turbo-darwin-arm64@2.4.4:
-    resolution: {integrity: sha512-/gtHPqbGQXDFhrmy+Q/MFW2HUTUlThJ97WLLSe4bxkDrKHecDYhAjbZ4rN3MM93RV9STQb3Tqy4pZBtsd4DfCw==}
+  turbo-darwin-arm64@2.5.2:
+    resolution: {integrity: sha512-MrFYhK/jYu8N6QlqZtqSHi3e4QVxlzqU3ANHTKn3/tThuwTLbNHEvzBPWSj5W7nZcM58dCqi6gYrfRz6bJZyAA==}
     cpu: [arm64]
     os: [darwin]
 
-  turbo-linux-64@2.4.4:
-    resolution: {integrity: sha512-SR0gri4k0bda56hw5u9VgDXLKb1Q+jrw4lM7WAhnNdXvVoep4d6LmnzgMHQQR12Wxl3KyWPbkz9d1whL6NTm2Q==}
+  turbo-linux-64@2.5.2:
+    resolution: {integrity: sha512-LxNqUE2HmAJQ/8deoLgMUDzKxd5bKxqH0UBogWa+DF+JcXhtze3UTMr6lEr0dEofdsEUYK1zg8FRjglmwlN5YA==}
     cpu: [x64]
     os: [linux]
 
-  turbo-linux-arm64@2.4.4:
-    resolution: {integrity: sha512-COXXwzRd3vslQIfJhXUklgEqlwq35uFUZ7hnN+AUyXx7hUOLIiD5NblL+ETrHnhY4TzWszrbwUMfe2BYWtaPQg==}
+  turbo-linux-arm64@2.5.2:
+    resolution: {integrity: sha512-0MI1Ao1q8zhd+UUbIEsrM+yLq1BsrcJQRGZkxIsHFlGp7WQQH1oR3laBgfnUCNdCotCMD6w4moc9pUbXdOR3bg==}
     cpu: [arm64]
     os: [linux]
 
-  turbo-windows-64@2.4.4:
-    resolution: {integrity: sha512-PV9rYNouGz4Ff3fd6sIfQy5L7HT9a4fcZoEv8PKRavU9O75G7PoDtm8scpHU10QnK0QQNLbE9qNxOAeRvF0fJg==}
+  turbo-windows-64@2.5.2:
+    resolution: {integrity: sha512-hOLcbgZzE5ttACHHyc1ajmWYq4zKT42IC3G6XqgiXxMbS+4eyVYTL+7UvCZBd3Kca1u4TLQdLQjeO76zyDJc2A==}
     cpu: [x64]
     os: [win32]
 
-  turbo-windows-arm64@2.4.4:
-    resolution: {integrity: sha512-403sqp9t5sx6YGEC32IfZTVWkRAixOQomGYB8kEc6ZD+//LirSxzeCHCnM8EmSXw7l57U1G+Fb0kxgTcKPU/Lg==}
+  turbo-windows-arm64@2.5.2:
+    resolution: {integrity: sha512-fMU41ABhSLa18H8V3Z7BMCGynQ8x+wj9WyBMvWm1jeyRKgkvUYJsO2vkIsy8m0vrwnIeVXKOIn6eSe1ddlBVqw==}
     cpu: [arm64]
     os: [win32]
 
-  turbo@2.4.4:
-    resolution: {integrity: sha512-N9FDOVaY3yz0YCOhYIgOGYad7+m2ptvinXygw27WPLQvcZDl3+0Sa77KGVlLSiuPDChOUEnTKE9VJwLSi9BPGQ==}
+  turbo@2.5.2:
+    resolution: {integrity: sha512-Qo5lfuStr6LQh3sPQl7kIi243bGU4aHGDQJUf6ylAdGwks30jJFloc9NYHP7Y373+gGU9OS0faA4Mb5Sy8X9Xw==}
     hasBin: true
 
   tw-animate-css@1.2.8:
@@ -18224,32 +18223,32 @@ snapshots:
       safe-buffer: 5.2.1
     optional: true
 
-  turbo-darwin-64@2.4.4:
+  turbo-darwin-64@2.5.2:
     optional: true
 
-  turbo-darwin-arm64@2.4.4:
+  turbo-darwin-arm64@2.5.2:
     optional: true
 
-  turbo-linux-64@2.4.4:
+  turbo-linux-64@2.5.2:
     optional: true
 
-  turbo-linux-arm64@2.4.4:
+  turbo-linux-arm64@2.5.2:
     optional: true
 
-  turbo-windows-64@2.4.4:
+  turbo-windows-64@2.5.2:
     optional: true
 
-  turbo-windows-arm64@2.4.4:
+  turbo-windows-arm64@2.5.2:
     optional: true
 
-  turbo@2.4.4:
+  turbo@2.5.2:
     optionalDependencies:
-      turbo-darwin-64: 2.4.4
-      turbo-darwin-arm64: 2.4.4
-      turbo-linux-64: 2.4.4
-      turbo-linux-arm64: 2.4.4
-      turbo-windows-64: 2.4.4
-      turbo-windows-arm64: 2.4.4
+      turbo-darwin-64: 2.5.2
+      turbo-darwin-arm64: 2.5.2
+      turbo-linux-64: 2.5.2
+      turbo-linux-arm64: 2.5.2
+      turbo-windows-64: 2.5.2
+      turbo-windows-arm64: 2.5.2
 
   tw-animate-css@1.2.8: {}
 

--- a/turbo.json
+++ b/turbo.json
@@ -53,5 +53,6 @@
       "cache": false
     }
   },
-  "ui": "tui"
+  "ui": "tui",
+  "concurrency": "15"
 }


### PR DESCRIPTION
This pull request updates the `turbo` package to version 2.5.2 across multiple files and introduces a new concurrency setting in the `turbo.json` configuration file. Below is a breakdown of the most important changes:

### Dependency Updates

* Updated the `turbo` package from version 2.4.4 to 2.5.2 in `package.json` to ensure compatibility with the latest features and fixes.
* Updated the `turbo` package version and its platform-specific resolutions (e.g., `darwin`, `linux`, `windows`) in `pnpm-lock.yaml` under `importers`, `packages`, and `snapshots` sections to align with the new version. [[1]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL52-R53) [[2]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL8076-R8106) [[3]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL18227-R18251)

### Configuration Changes

* Added a new `"concurrency": "15"` setting to the `turbo.json` file, which specifies the maximum number of tasks that can run concurrently.